### PR TITLE
feat(admin/categories): add REST API, slug generation, validation & initial data

### DIFF
--- a/mysql/init/init.sql
+++ b/mysql/init/init.sql
@@ -108,7 +108,7 @@ CREATE TABLE IF NOT EXISTS `callbacks` (
 );
 CREATE TABLE IF NOT EXISTS `categories` (
                                  `id` int(11) NOT NULL AUTO_INCREMENT,
-                                 `parent_id` int(11) DEFAULT NULL,
+                                 `parent_id` BIGINT DEFAULT NULL,
                                  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
                                  `name_h1` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
                                  `meta_title` varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
@@ -116,6 +116,7 @@ CREATE TABLE IF NOT EXISTS `categories` (
                                  `meta_description` varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
                                  `annotation` mediumtext COLLATE utf8mb4_unicode_ci,
                                  `description` mediumtext COLLATE utf8mb4_unicode_ci,
+                                 `slug` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
                                  `url` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
                                  `image` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
                                  `position` int(11) NOT NULL DEFAULT '0',
@@ -129,7 +130,7 @@ CREATE TABLE IF NOT EXISTS `categories` (
                                  `auto_description` mediumtext COLLATE utf8mb4_unicode_ci,
                                  `auto_annotation` mediumtext COLLATE utf8mb4_unicode_ci,
                                  `updatedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-                                 `createdAt` timestamp NULL DEFAULT NULL,
+                                 `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
                                  `auto_h1` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
                                  PRIMARY KEY (`id`),
                                  KEY `parent_id` (`parent_id`),
@@ -567,3 +568,9 @@ CREATE TABLE IF NOT EXISTS `variants` (
 );
 
 UPDATE categories SET parent_id = NULL WHERE parent_id = 0;
+INSERT INTO categories (name, slug, parent_id, visible) VALUES
+                                                            ('Electronics', 'electronics', NULL, 1),
+                                                            ('Phones', 'phones', 1, 1),
+                                                            ('Laptops', 'laptops', 1, 1),
+                                                            ('Clothing', 'clothing', NULL, 1),
+                                                            ('Men Clothing', 'men-clothing', 4, 1);

--- a/mysql/init/init.sql
+++ b/mysql/init/init.sql
@@ -128,15 +128,15 @@ CREATE TABLE IF NOT EXISTS `categories` (
                                  `auto_meta_desc` varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
                                  `auto_description` mediumtext COLLATE utf8mb4_unicode_ci,
                                  `auto_annotation` mediumtext COLLATE utf8mb4_unicode_ci,
-                                 `last_modify` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-                                 `created` timestamp NULL DEFAULT NULL,
+                                 `updatedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                                 `createdAt` timestamp NULL DEFAULT NULL,
                                  `auto_h1` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
                                  PRIMARY KEY (`id`),
                                  KEY `parent_id` (`parent_id`),
                                  KEY `position` (`position`),
                                  KEY `visible` (`visible`),
                                  KEY `external_id` (`external_id`),
-                                 KEY `created` (`created`),
+                                 KEY `created` (`createdAt`),
                                  KEY `url` (`url`(100))
 );
 CREATE TABLE IF NOT EXISTS `categories_features` (

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,12 @@
       <artifactId>lombok</artifactId>
       <version>1.18.38</version>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/com.github.slugify/slugify -->
+    <dependency>
+      <groupId>com.github.slugify</groupId>
+      <artifactId>slugify</artifactId>
+      <version>3.0.7</version>
+    </dependency>
   </dependencies>
   <build>
     <finalName>OnlineStore</finalName>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,18 @@
       <artifactId>slugify</artifactId>
       <version>3.0.7</version>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.19.1</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jsr310 -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>2.19.1</version>
+    </dependency>
   </dependencies>
   <build>
     <finalName>OnlineStore</finalName>

--- a/src/main/java/com/onlineshop/config/WebConfig.java
+++ b/src/main/java/com/onlineshop/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.onlineshop.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        converters.add(new MappingJackson2HttpMessageConverter());
+    }
+}

--- a/src/main/java/com/onlineshop/controller/CategoryController.java
+++ b/src/main/java/com/onlineshop/controller/CategoryController.java
@@ -1,63 +1,82 @@
 package com.onlineshop.controller;
 
+import com.onlineshop.dto.CategoryCreateDto;
 import com.onlineshop.entity.CategoryNode;
 import com.onlineshop.entity.Category;
 import com.onlineshop.service.CategoryService;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/admin/categories")
+@RequestMapping("/api/admin/categories")
 public class CategoryController {
 
     @Autowired
     private CategoryService categoryService;
 
-    @GetMapping
-    public String showAllCategories(Model model) {
-        List<Category> all = categoryService.getAll();
-        List<CategoryNode> tree = categoryService.buildCategoryTree(all);
-        model.addAttribute("categoryTree", tree);
-        return "categories/list";
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<Category> getAllCategories(
+            @RequestParam(value = "visible", required = false) Boolean visible,
+            @RequestParam(value = "parentId", required = false) Long parentId) {
+        return categoryService.find(visible, parentId);
     }
 
-    @GetMapping("/new")
-    public String newCategoryForm(Model model) {
-        model.addAttribute("category", new Category());
-        model.addAttribute("allCategories", categoryService.getAll());
-        return "categories/form";
+    @GetMapping(value = "/tree", produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<CategoryNode> getCategoryTree(
+            @RequestParam(value = "visible", required = false) Boolean visible,
+            @RequestParam(value = "parentId", required = false) Long parentId
+    ) {
+        return categoryService.getCategoryTree(visible, parentId);
     }
 
-    @PostMapping("/save")
-    public String saveCategory(@ModelAttribute("category") Category category) {
-        categoryService.save(category);
-        return "redirect:/admin/categories";
-    }
-
-    @GetMapping("/edit")
-    public String editCategory(@RequestParam("id") int id, Model model) {
-        model.addAttribute("category", categoryService.get(id));
-        model.addAttribute("allCategories", categoryService.getAll());
-        return "categories/form";
-    }
-
-    @GetMapping("/delete")
-    public String deleteCategory(@RequestParam("id") int id) {
-        categoryService.delete(id);
-        return "redirect:/admin/categories";
-    }
-
-    @GetMapping
-    public String restoreCategory(@RequestParam("id") int id) {
+    @GetMapping("/{id}")
+    public ResponseEntity<Category> getCategoryById(@PathVariable("id") long id) {
         Category category = categoryService.get(id);
-        if (category != null) {
-            category.setVisible(true);
-            categoryService.save(category);
+        if (category == null || Boolean.FALSE.equals(category.getVisible())) {
+            throw new RuntimeException("Category not found or deactivated");
         }
-        return "redirect:/admin/categories";
+        return ResponseEntity.ok(category);
+    }
+
+    @PostMapping
+    public ResponseEntity<Category> createCategory(@Valid @RequestBody CategoryCreateDto dto) {
+        Category category = new Category();
+        category.setName(dto.getName());
+        category.setParentId(dto.getParentId());
+        category.setVisible(dto.getVisible());
+        category.setUrl(dto.getUrl());
+
+        categoryService.save(category);
+        return ResponseEntity.ok(category);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Category> updateCategory(@PathVariable("id") long id,
+                                                   @Valid @RequestBody Category updatedCategory) {
+        Category existing = categoryService.get(id);
+        if (existing == null) {
+            throw new RuntimeException("Category not found");
+        }
+        existing.setName(updatedCategory.getName());
+        existing.setParentId(updatedCategory.getParentId());
+        existing.setVisible(updatedCategory.getVisible());
+
+        categoryService.save(existing);
+        return ResponseEntity.ok(updatedCategory);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteCategory(@PathVariable("id") long id) {
+        Category category = categoryService.get(id);
+        if (category == null) {
+            throw new RuntimeException("Category not found");
+        }
+        category.setVisible(false);
+        categoryService.save(category);
     }
 }

--- a/src/main/java/com/onlineshop/controller/CategoryController.java
+++ b/src/main/java/com/onlineshop/controller/CategoryController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Controller
+@RestController
 @RequestMapping("/admin/categories")
 public class CategoryController {
 
@@ -48,6 +48,16 @@ public class CategoryController {
     @GetMapping("/delete")
     public String deleteCategory(@RequestParam("id") int id) {
         categoryService.delete(id);
+        return "redirect:/admin/categories";
+    }
+
+    @GetMapping
+    public String restoreCategory(@RequestParam("id") int id) {
+        Category category = categoryService.get(id);
+        if (category != null) {
+            category.setVisible(true);
+            categoryService.save(category);
+        }
         return "redirect:/admin/categories";
     }
 }

--- a/src/main/java/com/onlineshop/controller/ValidationExceptionHandler.java
+++ b/src/main/java/com/onlineshop/controller/ValidationExceptionHandler.java
@@ -1,0 +1,27 @@
+package com.onlineshop.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class ValidationExceptionHandler {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationErrors(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+                errors.put(error.getField(), error.getDefaultMessage()));
+        return ResponseEntity.badRequest().body(errors);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException ex) {
+        Map<String, String> error = new HashMap<>();
+        error.put("error", ex.getMessage());
+        return ResponseEntity.badRequest().body(error);
+    }
+}

--- a/src/main/java/com/onlineshop/dao/category/CategoryDAO.java
+++ b/src/main/java/com/onlineshop/dao/category/CategoryDAO.java
@@ -11,8 +11,12 @@ public interface CategoryDAO {
 
     void saveCategory(Category category);
 
-    Category getCategory(int id);
+    Category getCategory(long id);
 
-    void deleteCategory(int id);
+    void deleteCategory(long id);
+
     boolean slugExists(String slug);
+
+    List<Category> findCategories(Boolean visible, Long parentId);
+
 }

--- a/src/main/java/com/onlineshop/dao/category/CategoryDAO.java
+++ b/src/main/java/com/onlineshop/dao/category/CategoryDAO.java
@@ -7,9 +7,12 @@ import java.util.List;
 public interface CategoryDAO {
     List<Category> getAllCategories();
 
+    List<Category> getAllCategoriesIncludingHidden();
+
     void saveCategory(Category category);
 
     Category getCategory(int id);
 
     void deleteCategory(int id);
+    boolean slugExists(String slug);
 }

--- a/src/main/java/com/onlineshop/dao/category/CategoryDAOImpl.java
+++ b/src/main/java/com/onlineshop/dao/category/CategoryDAOImpl.java
@@ -15,7 +15,12 @@ public class CategoryDAOImpl implements CategoryDAO {
 
     @Override
     public List<Category> getAllCategories() {
-        return entityManager.createQuery("from Category", Category.class).getResultList();
+        return entityManager.createQuery("FROM Category c WHERE c.visible = true", Category.class).getResultList();
+    }
+
+    @Override
+    public List<Category> getAllCategoriesIncludingHidden() {
+        return entityManager.createQuery("FROM Category", Category.class).getResultList();
     }
 
     @Override
@@ -36,7 +41,15 @@ public class CategoryDAOImpl implements CategoryDAO {
     public void deleteCategory(int id) {
         Category category = getCategory(id);
         if (category != null) {
-            entityManager.remove(category);
+            category.setVisible(false);
+            entityManager.merge(category);
         }
+    }
+
+    public boolean slugExists(String slug) {
+        Long count = entityManager.createQuery("SELECT COUNT(c) FROM Category c WHERE c.slug = :slug", Long.class)
+                .setParameter("slug", slug)
+                .getSingleResult();
+        return count > 0;
     }
 }

--- a/src/main/java/com/onlineshop/dto/CategoryCreateDto.java
+++ b/src/main/java/com/onlineshop/dto/CategoryCreateDto.java
@@ -1,0 +1,17 @@
+package com.onlineshop.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class CategoryCreateDto {
+    @NotBlank
+    private String name;
+    private Long parentId;
+    @NotNull
+    private Boolean visible;
+    @NotBlank
+    private String url;
+
+}

--- a/src/main/java/com/onlineshop/entity/Category.java
+++ b/src/main/java/com/onlineshop/entity/Category.java
@@ -1,10 +1,18 @@
 package com.onlineshop.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.ToString;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,22 +25,25 @@ public class Category {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @JsonBackReference
     @ToString.Exclude
     @ManyToOne
     @JoinColumn(name = "parent_id", insertable = false, updatable = false)
     private Category parent;
 
+    @JsonManagedReference
     @ToString.Exclude
     @OneToMany(mappedBy = "parent", fetch = FetchType.EAGER)
     private List<Category> children = new ArrayList<>();
 
     @Column(name = "parent_id")
-    private Integer parentId;
+    private Long parentId;
 
     @Column(nullable = false)
+    @NotBlank(message = "name is required")
     private String name = "";
 
-    @Column(unique = true)
+    @Column(nullable = false, unique = true)
     private String slug = "";
 
     @Column(name = "name_h1", nullable = false)
@@ -63,6 +74,7 @@ public class Category {
     private Integer position = 0;
 
     @Column(nullable = false)
+    @NotNull(message = "Status (visible) is required")
     private Boolean visible = false;
 
     @Column(name = "show_table_content", nullable = false)
@@ -89,10 +101,15 @@ public class Category {
     @Column(name = "auto_annotation", columnDefinition = "mediumtext")
     private String autoAnnotation = "";
 
-    @Column(name = "updatedAt", insertable = false, updatable = false)
-    private Timestamp lastModify;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @UpdateTimestamp
+    @Column(name = "updatedAt")
+    private LocalDateTime lastModify;
 
-    private Timestamp createdAt;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @CreationTimestamp
+    @Column(name = "createdAt", nullable = false)
+    private LocalDateTime createdAt;
 
     @Column(name = "auto_h1")
     private String autoH1 = "";

--- a/src/main/java/com/onlineshop/entity/Category.java
+++ b/src/main/java/com/onlineshop/entity/Category.java
@@ -15,7 +15,7 @@ public class Category {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    private Long id;
 
     @ToString.Exclude
     @ManyToOne
@@ -31,6 +31,9 @@ public class Category {
 
     @Column(nullable = false)
     private String name = "";
+
+    @Column(unique = true)
+    private String slug = "";
 
     @Column(name = "name_h1", nullable = false)
     private String nameH1 = "";
@@ -86,10 +89,10 @@ public class Category {
     @Column(name = "auto_annotation", columnDefinition = "mediumtext")
     private String autoAnnotation = "";
 
-    @Column(name = "last_modify", insertable = false, updatable = false)
+    @Column(name = "updatedAt", insertable = false, updatable = false)
     private Timestamp lastModify;
 
-    private Timestamp created;
+    private Timestamp createdAt;
 
     @Column(name = "auto_h1")
     private String autoH1 = "";

--- a/src/main/java/com/onlineshop/entity/CategoryNode.java
+++ b/src/main/java/com/onlineshop/entity/CategoryNode.java
@@ -6,9 +6,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Data
-@RequiredArgsConstructor
 public class CategoryNode {
-    @NonNull
-    private Category category;
+    private Long id;
+    private String name;
+    private Long parentId;
     private List<CategoryNode> children = new ArrayList<>();
+
+    public CategoryNode(Category category) {
+        this.id = category.getId();
+        this.name = category.getName();
+        this.parentId = category.getParentId();
+    }
 }

--- a/src/main/java/com/onlineshop/service/CategoryService.java
+++ b/src/main/java/com/onlineshop/service/CategoryService.java
@@ -2,19 +2,25 @@ package com.onlineshop.service;
 
 import com.onlineshop.entity.CategoryNode;
 import com.onlineshop.entity.Category;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 public interface CategoryService {
     List<Category> getAll();
 
+    List<Category> getAllIncludingHidden();
+
     void save(Category category);
 
-    Category get(int id);
+    Category get(long id);
 
-    void delete(int id);
+    void delete(long id);
 
     List<CategoryNode> buildCategoryTree(List<Category> categories);
 
+    List<Category> find(Boolean visible, Long parentId);
+
+    List<CategoryNode> getCategoryTree(Boolean visible, Long parentId);
 
 }

--- a/src/main/java/com/onlineshop/service/CategoryServiceImpl.java
+++ b/src/main/java/com/onlineshop/service/CategoryServiceImpl.java
@@ -27,38 +27,50 @@ public class CategoryServiceImpl implements CategoryService {
 
     @Override
     @Transactional
-    public void save(Category category) {
-        if (category.getSlug() == null || category.getSlug().isEmpty()) {
-            String generatedSlug = SlugUtil.toSlug(category.getName());
-            int suffix = 1;
-            String originalSlug = generatedSlug;
-            while (categoryDAO.slugExists(generatedSlug)) {
-                generatedSlug = originalSlug + "-" + suffix++;
-            }
-            category.setSlug(generatedSlug);
-        }
-        if (category.getParentId() != null) {
-            Category parent = categoryDAO.getCategory(category.getParentId());
-            if (parent == null) {
-                throw new IllegalArgumentException("Parent category with ID " + category.getParentId() + "does no exist.");
-            }
-        }
-        categoryDAO.saveCategory(category);
+    public List<Category> getAllIncludingHidden() {
+        return categoryDAO.getAllCategoriesIncludingHidden();
     }
 
     @Override
     @Transactional
-    public Category get(int id) {
+    public void save(Category category) {
+        try {
+            if (category.getSlug() == null || category.getSlug().isBlank()) {
+                String baseSlug = SlugUtil.toSlug(category.getName());
+                String uniqueSlug = baseSlug;
+                long suffix = 1;
+                while (categoryDAO.slugExists(uniqueSlug)) {
+                    uniqueSlug = baseSlug + "-" + suffix++;
+                }
+                category.setSlug(uniqueSlug);
+            }
+            if (category.getParentId() != null && category.getParentId() != 0L) {
+                Category parent = categoryDAO.getCategory(category.getParentId().intValue());
+                if (parent == null) {
+                    throw new IllegalArgumentException("Parent category with ID " + category.getParentId() + " does no exist.");
+                }
+            }
+            categoryDAO.saveCategory(category);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+
+    @Override
+    @Transactional
+    public Category get(long id) {
         return categoryDAO.getCategory(id);
     }
 
     @Override
     @Transactional
-    public void delete(int id) {
+    public void delete(long id) {
         categoryDAO.deleteCategory(id);
     }
 
     @Override
+    @Transactional
     public List<CategoryNode> buildCategoryTree(List<Category> categories) {
         Map<Long, CategoryNode> map = new HashMap<>();
         List<CategoryNode> roots = new ArrayList<>();
@@ -72,12 +84,47 @@ public class CategoryServiceImpl implements CategoryService {
             if (c.getParentId() == null || c.getParentId() == 0) {
                 roots.add(node);
             } else {
-                CategoryNode parent = map.get(c.getParentId());
-                if (parent != null) {
-                    parent.getChildren().add(node);
+                CategoryNode parentNode = map.get(c.getParentId());
+                if (parentNode != null) {
+                    parentNode.getChildren().add(node);
+                    node.setParentId(parentNode.getId());
+                } else {
+                    roots.add(node);
                 }
             }
         }
         return roots;
+    }
+
+    @Override
+    @Transactional
+    public List<Category> find(Boolean visible, Long parentId) {
+        return categoryDAO.findCategories(visible, parentId);
+    }
+
+    @Override
+    public List<CategoryNode> getCategoryTree(Boolean visible, Long parentId) {
+        List<Category> categories = find(visible, null);
+        List<CategoryNode> fullTree = buildCategoryTree(categories);
+
+        if (parentId != null) {
+            CategoryNode subtree = findSubtreeNode(fullTree, parentId);
+            return subtree != null ? List.of(subtree) : List.of();
+        }
+
+        return fullTree;
+    }
+
+    private CategoryNode findSubtreeNode(List<CategoryNode> nodes, Long parentId) {
+        for (CategoryNode node : nodes) {
+            if (node.getId().equals(parentId)) {
+                return node;
+            }
+            CategoryNode found = findSubtreeNode(node.getChildren(), parentId);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/onlineshop/util/SlugUtil.java
+++ b/src/main/java/com/onlineshop/util/SlugUtil.java
@@ -1,11 +1,99 @@
 package com.onlineshop.util;
 
-import com.github.slugify.Slugify;
+import java.util.HashMap;
+import java.util.Map;
 
 public class SlugUtil {
-    private static final Slugify slugify = Slugify.builder().lowerCase(true).build();
+    private static final Map<Character, String> translitMap = new HashMap<>();
 
-    public static String toSlug (String input){
-        return slugify.slugify(input);
+    static {
+        translitMap.put('А', "A");
+        translitMap.put('а', "a");
+        translitMap.put('Б', "B");
+        translitMap.put('б', "b");
+        translitMap.put('В', "V");
+        translitMap.put('в', "v");
+        translitMap.put('Г', "H");
+        translitMap.put('г', "h");
+        translitMap.put('Ґ', "G");
+        translitMap.put('ґ', "g");
+        translitMap.put('Д', "D");
+        translitMap.put('д', "d");
+        translitMap.put('Е', "E");
+        translitMap.put('е', "e");
+        translitMap.put('Є', "Ye");
+        translitMap.put('є', "ie");
+        translitMap.put('Ж', "Zh");
+        translitMap.put('ж', "zh");
+        translitMap.put('З', "Z");
+        translitMap.put('з', "z");
+        translitMap.put('И', "Y");
+        translitMap.put('и', "y");
+        translitMap.put('І', "I");
+        translitMap.put('і', "i");
+        translitMap.put('Ї', "Yi");
+        translitMap.put('ї', "i");
+        translitMap.put('Й', "Y");
+        translitMap.put('й', "i");
+        translitMap.put('К', "K");
+        translitMap.put('к', "k");
+        translitMap.put('Л', "L");
+        translitMap.put('л', "l");
+        translitMap.put('М', "M");
+        translitMap.put('м', "m");
+        translitMap.put('Н', "N");
+        translitMap.put('н', "n");
+        translitMap.put('О', "O");
+        translitMap.put('о', "o");
+        translitMap.put('П', "P");
+        translitMap.put('п', "p");
+        translitMap.put('Р', "R");
+        translitMap.put('р', "r");
+        translitMap.put('С', "S");
+        translitMap.put('с', "s");
+        translitMap.put('Т', "T");
+        translitMap.put('т', "t");
+        translitMap.put('У', "U");
+        translitMap.put('у', "u");
+        translitMap.put('Ф', "F");
+        translitMap.put('ф', "f");
+        translitMap.put('Х', "Kh");
+        translitMap.put('х', "kh");
+        translitMap.put('Ц', "Ts");
+        translitMap.put('ц', "ts");
+        translitMap.put('Ч', "Ch");
+        translitMap.put('ч', "ch");
+        translitMap.put('Ш', "Sh");
+        translitMap.put('ш', "sh");
+        translitMap.put('Щ', "Shch");
+        translitMap.put('щ', "shch");
+        translitMap.put('Ю', "Yu");
+        translitMap.put('ю', "iu");
+        translitMap.put('Я', "Ya");
+        translitMap.put('я', "ia");
+        translitMap.put('Ь', "");
+        translitMap.put('ь', "");
+        translitMap.put('\'', "");
+        translitMap.put('’', ""); // апострофи
+    }
+
+    public static String toSlug(String input) {
+        if (input == null || input.isBlank()) return "";
+
+        StringBuilder sb = new StringBuilder();
+
+        for (char c : input.trim().toCharArray()) {
+            if (Character.isLetterOrDigit(c)) {
+                sb.append(translitMap.getOrDefault(c, String.valueOf(c)));
+            } else {
+                sb.append('-');
+            }
+        }
+
+        String slug = sb.toString().toLowerCase()
+                .replaceAll("-{2,}", "-")
+                .replaceAll("^-|-$", "");
+
+        return slug;
     }
 }

--- a/src/main/java/com/onlineshop/util/SlugUtil.java
+++ b/src/main/java/com/onlineshop/util/SlugUtil.java
@@ -1,0 +1,11 @@
+package com.onlineshop.util;
+
+import com.github.slugify.Slugify;
+
+public class SlugUtil {
+    private static final Slugify slugify = Slugify.builder().lowerCase(true).build();
+
+    public static String toSlug (String input){
+        return slugify.slugify(input);
+    }
+}


### PR DESCRIPTION
Adds an admin module for managing categories via REST API.

Features
	•	Admin REST Controller (/api/admin/categories)
	•	CRUD endpoints:
	•	GET /api/admin/categories
        •	GET /api/admin/categories/tree
        •	GET /api/admin/categories/tree?parentId={id}
        •	GET /api/admin/categories/tree?visible={true/false}
	•	GET /api/admin/categories/{id}
	•	POST /api/admin/categories
	•	PUT /api/admin/categories/{id}
	•	DELETE /api/admin/categories/{id}
	•	Slug generation
	•	Create URL-friendly slugs from category names
	•	Enforces uniqueness in the database (@Column(unique = true))
	•	Bean Validation
	•	DTO fields annotated with @NotBlank, @NotNull, etc.
	•	Incoming @RequestBody @Valid requests are validated automatically
	•	Error handling
	•	Global @RestControllerAdvice catches MethodArgumentNotValidException
	•	Returns structured JSON with field-level validation errors
	•	Initial data loader
	•	On application startup, seeds the database with at least 5 sample categories

How to Test
	1.	Start the application.
	2.	POST to /api/admin/categories with valid and invalid payloads.
	3.	Verify that:
	•	New categories are created with unique, slugified names.
	•	Validation failures return HTTP 400 with a JSON error body.
	4.	Check the database to ensure ≥5 categories exist after startup.

Please review and let me know if anything needs to be adjusted!